### PR TITLE
Feature/basic browsing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import { useBrokerConfig } from './providers/BrokerConfigProvider';
+import { useQueueBrowsing } from './hooks/solace';
 
 import DesktopContainer from './components/DesktopContainer';
 import RootLayout from './components/RootLayout';
@@ -9,20 +10,25 @@ import MessageList from './components/MessageList';
 import MessagePayloadView from './components/MessagePayloadView';
 import MessageHeaderView from './components/MessageHeaderView';
 
-
 import 'primeflex/primeflex.css';
 import 'primeicons/primeicons.css';
 import './App.css';
 
 export default function App() {
+  const { brokers, brokerEditor } = useBrokerConfig();
+  
   const [selectedSource, setSelectedSource] = useState({});
   const [selectedMessage, setSelectedMessage] = useState({});
 
-  const { brokers, brokerEditor } = useBrokerConfig();
+  const [browser, updateBrowser] = useQueueBrowsing();
 
-  const handleSourceSelected = (queue) => {
-    setSelectedSource(queue);
+  const handleSourceSelected = (source) => {
     setSelectedMessage({});
+    setSelectedSource(source);
+  };
+
+  const handleBrowseFromChange = (browseFrom) => {
+    updateBrowser(selectedSource, browseFrom);
   };
 
   const handleMessageSelect = (message) => {
@@ -39,8 +45,10 @@ export default function App() {
           </RootLayout.LeftPanel>
           <RootLayout.CenterPanel>
             <MessageList 
-              sourceDefinition={selectedSource} 
-              selectedMessage={selectedMessage} 
+              sourceDefinition={selectedSource}
+              browser={browser}
+              selectedMessage={selectedMessage}
+              onBrowseFromChange={handleBrowseFromChange}
               onMessageSelect={handleMessageSelect} 
             />
           </RootLayout.CenterPanel>

--- a/src/components/BrokerQueueTreeView/index.jsx
+++ b/src/components/BrokerQueueTreeView/index.jsx
@@ -95,7 +95,7 @@ export default function TreeView({ brokers, brokerEditor, onSourceSelected }) {
         key: `queue/${n}`,
         label: queue.queueName,
         data: {
-          type: 'queue',
+          type: config.testResult.replay ? 'queue' : 'basic',
           toolIcon: '',
           config,
           sourceName: queue.queueName
@@ -124,7 +124,6 @@ export default function TreeView({ brokers, brokerEditor, onSourceSelected }) {
   }
 
   const handleExpand = async (event) => {
-    console.log('handleExpand', event.node);
     const { node } = event;
     const { type, config } = node.data;
 
@@ -151,8 +150,7 @@ export default function TreeView({ brokers, brokerEditor, onSourceSelected }) {
   };
 
   const handleSelect = (event) => {
-    console.log('handleSelect', event.node.data);
-    if (event.node.data.type === 'queue' || event.node.data.type === 'topic') {
+    if (event.node.data.type === 'queue' || event.node.data.type === 'topic' || event.node.data.type === 'basic') {
       onSourceSelected?.(event.node.data);
     }
   };

--- a/src/components/MessageList/MessageListToolbar.jsx
+++ b/src/components/MessageList/MessageListToolbar.jsx
@@ -1,0 +1,170 @@
+import { useEffect, useState } from 'react';
+
+import { Button } from 'primereact/button';
+import { Calendar } from 'primereact/calendar';
+import { Checkbox } from 'primereact/checkbox';
+import { Dropdown } from 'primereact/dropdown';
+import { InputText } from 'primereact/inputtext';
+import { Toolbar } from 'primereact/toolbar';
+
+import { SOURCE_TYPE, BROWSE_MODE, SUPPORTED_BROWSE_MODES, MESSAGE_ORDER } from '../../hooks/solace';
+
+import classes from './styles.module.css';
+
+export default function MessageListToolbar({ sourceDefinition, onChange }) {
+  const { type: sourceType, sourceName, config: { id: brokerId } } = sourceDefinition;
+
+  const [sourceLabel, browseModes] =
+    (sourceType === SOURCE_TYPE.BASIC) ? [
+      'Queue', [
+        { value: BROWSE_MODE.HEAD, name: 'Queue Head' }
+      ]
+    ] : (sourceType === SOURCE_TYPE.QUEUE) ? [
+      'Queue', [
+        { value: BROWSE_MODE.HEAD, name: 'Queue Head' },
+        { value: BROWSE_MODE.TAIL, name: 'Queue End' },
+        { value: BROWSE_MODE.TIME, name: 'Date / Time' },
+        { value: BROWSE_MODE.MSGID, name: 'Message ID' }
+      ]] : (sourceType === SOURCE_TYPE.TOPIC) ? [
+        'Topic', [
+          { value: BROWSE_MODE.TIME, name: 'Date / Time' },
+          { value: BROWSE_MODE.MSGID, name: 'Message ID' }
+        ]
+      ] : [
+      '', [
+        { value: null }
+      ]
+    ];
+
+  const [browseMode, setBrowseMode] = useState(browseModes[0].value);
+  const [calendarVisible, setCalendarVisible] = useState(false);
+  const [calendarMinMax, setCalendarMinMax] = useState({});
+
+  // Browse Start Points
+  const [basicMode, setBasicMode] = useState(false);
+  const [dateTime, setDateTime] = useState(null);
+  const [msgId, setMsgId] = useState('');
+
+  const basicSource = (sourceType === SOURCE_TYPE.BASIC);
+
+  const getFromTime = () => {
+    try {
+      const fromTime = dateTime ? Math.floor(Date.parse(dateTime) / 1000) : null;
+      return ({ fromTime });
+    } catch {
+      console.error('Invalid date format'); //TODO: send toast notification
+      return ({ fromTime: null });
+    }
+  }
+
+  const getFromMsgId = () => {
+    try {
+      const fromMsgId = msgId.startsWith('rmid1:') ?
+        window.parseInt(msgId.substring(24).replace('-', ''), 16) :
+        window.parseInt(msgId);
+      return ((fromMsgId > 0) ? { fromMsgId } : { fromTime: null });
+    } catch {
+      console.error('Invalid message id'); //TODO: send toast notification
+      return ({ fromTime: null });
+    }
+  }
+
+  useEffect(() => {
+    const coercedBrowseMode =
+      (basicSource) ?
+        BROWSE_MODE.HEAD :
+        (!SUPPORTED_BROWSE_MODES[sourceType].includes(browseMode)) ?
+          SUPPORTED_BROWSE_MODES[sourceType][0] :
+          browseMode;
+
+    if (browseMode !== coercedBrowseMode) {
+      setBrowseMode(coercedBrowseMode);
+    }
+    // trigger a refresh automatically when source has changed
+    raiseOnChange(coercedBrowseMode);
+  }, [brokerId, sourceType, sourceName]);
+
+  const raiseOnChange = (browseMode) => {
+    if (basicMode || basicSource) {
+      onChange({ browseMode: BROWSE_MODE.BASIC });
+      return;
+    }
+
+    switch (browseMode) {
+      case BROWSE_MODE.BASIC:
+      case BROWSE_MODE.HEAD:
+        onChange({ browseMode, startFrom: { queuePosition: MESSAGE_ORDER.OLDEST } });
+        break;
+      case BROWSE_MODE.TAIL:
+        onChange({ browseMode, startFrom: { queuePosition: MESSAGE_ORDER.NEWEST } });
+        break;
+      case BROWSE_MODE.TIME:
+        onChange({ browseMode, startFrom: getFromTime() });
+        break;
+      case BROWSE_MODE.MSGID:
+        onChange({ browseMode, startFrom: getFromMsgId() });
+        break;
+    }
+  };
+
+  const handleBrowseModeChange = ({ value: mode }) => {
+    setBrowseMode(mode);
+  };
+
+  const handleCalendarVisibleChangle = async () => {
+    if (calendarVisible) {
+      setCalendarVisible(false);
+    } else {
+      //const { min, max } = await browser?.getMinMaxFromTime();
+      setCalendarMinMax({
+        min: new Date('1/1/2024'), // new Date(min * 1000),
+        max: new Date('1/1/2026') // new Date(max * 1000)
+      });
+      setCalendarVisible(true);
+    }
+  };
+
+  const handleBasicModeChange = (e) => {
+    setBasicMode(e.checked);
+  };
+
+  const handleCalendarChange = (e) => {
+    setDateTime(e.value);
+  };
+
+  const handleMsgIdTextChange = (e) => {
+    setMsgId(e.target.value);
+  }
+
+  const handleRefreshClick = () => {
+    raiseOnChange(browseMode);
+  };
+
+  return (
+    <Toolbar className={classes.messageListToolbar}
+      start={() => <h3>{sourceLabel} | {sourceName}</h3>}
+      end={() =>
+        <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+          <label>From:</label>
+          <Dropdown value={browseMode} onChange={handleBrowseModeChange} options={browseModes} optionLabel="name" disabled={basicSource} />
+          {
+            ([BROWSE_MODE.HEAD, BROWSE_MODE.BASIC].includes(browseMode)) ?
+              <div style={{ display: 'flex', width: 188 }}>
+                <Checkbox inputId="simpleBrowser" onChange={handleBasicModeChange} checked={basicMode || basicSource} disabled={basicSource} />
+                <label htmlFor="simpleBrowser" className="ml-2">Basic Mode</label>
+              </div> :
+              (browseMode === BROWSE_MODE.TAIL) ?
+                <div style={{ display: 'flex', width: 188 }}></div> :
+                (browseMode === BROWSE_MODE.MSGID) ?
+                  <InputText placeholder="ID or RGMID" value={msgId} onChange={handleMsgIdTextChange} /> :
+                  (browseMode === BROWSE_MODE.TIME) ?
+                    <Calendar placeholder="Beginning of log" visible={calendarVisible} value={dateTime} showTime
+                      onVisibleChange={handleCalendarVisibleChangle} onChange={handleCalendarChange} minDate={calendarMinMax.min} maxDate={calendarMinMax.max}
+                    /> :
+                    <InputText disabled={true} placeholder="Invalid browse mode" />
+          }
+          <Button onClick={handleRefreshClick} size="small">Refresh</Button>
+        </div>}
+    />
+  );
+}

--- a/src/components/MessageList/MessageListToolbar.jsx
+++ b/src/components/MessageList/MessageListToolbar.jsx
@@ -11,7 +11,7 @@ import { SOURCE_TYPE, BROWSE_MODE, SUPPORTED_BROWSE_MODES, MESSAGE_ORDER } from 
 
 import classes from './styles.module.css';
 
-export default function MessageListToolbar({ sourceDefinition, onChange }) {
+export default function MessageListToolbar({ sourceDefinition, minTime, maxTime, onChange }) {
   const { type: sourceType, sourceName, config: { id: brokerId } } = sourceDefinition;
 
   const [sourceLabel, browseModes] =
@@ -36,9 +36,10 @@ export default function MessageListToolbar({ sourceDefinition, onChange }) {
       ]
     ];
 
+  const [minDate, maxDate] = [new Date(minTime * 1000), new Date(maxTime * 1000)];
+
   const [browseMode, setBrowseMode] = useState(browseModes[0].value);
   const [calendarVisible, setCalendarVisible] = useState(false);
-  const [calendarMinMax, setCalendarMinMax] = useState({});
 
   // Browse Start Points
   const [basicMode, setBasicMode] = useState(false);
@@ -115,11 +116,6 @@ export default function MessageListToolbar({ sourceDefinition, onChange }) {
     if (calendarVisible) {
       setCalendarVisible(false);
     } else {
-      //const { min, max } = await browser?.getMinMaxFromTime();
-      setCalendarMinMax({
-        min: new Date('1/1/2024'), // new Date(min * 1000),
-        max: new Date('1/1/2026') // new Date(max * 1000)
-      });
       setCalendarVisible(true);
     }
   };
@@ -159,7 +155,7 @@ export default function MessageListToolbar({ sourceDefinition, onChange }) {
                   <InputText placeholder="ID or RGMID" value={msgId} onChange={handleMsgIdTextChange} /> :
                   (browseMode === BROWSE_MODE.TIME) ?
                     <Calendar placeholder="Beginning of log" visible={calendarVisible} value={dateTime} showTime
-                      onVisibleChange={handleCalendarVisibleChangle} onChange={handleCalendarChange} minDate={calendarMinMax.min} maxDate={calendarMinMax.max}
+                      onVisibleChange={handleCalendarVisibleChangle} onChange={handleCalendarChange} minDate={minDate} maxDate={maxDate}
                     /> :
                     <InputText disabled={true} placeholder="Invalid browse mode" />
           }

--- a/src/components/MessageList/index.jsx
+++ b/src/components/MessageList/index.jsx
@@ -2,68 +2,34 @@ import { useEffect, useState } from 'react';
 
 import { DataTable } from 'primereact/datatable';
 import { Column } from 'primereact/column';
-import { Calendar } from 'primereact/calendar';
 import { Button } from 'primereact/button';
-import { Toolbar } from 'primereact/toolbar';
 import { InputText } from 'primereact/inputtext';
 import { IconField } from 'primereact/iconfield';
 import { InputIcon } from 'primereact/inputicon';
-import { Dropdown } from 'primereact/dropdown';
 import { FilterMatchMode } from 'primereact/api';
 
-import { useQueueBrowser, SOURCE_TYPE, MESSAGE_ORDER } from "../../hooks/solace";
+import MessageListToolbar from './MessageListToolbar';
 
 import classes from './styles.module.css';
 
-const BROWSE_MODE = {
-  HEAD: 'head',
-  TAIL: 'tail',
-  TIME: 'time',
-  MSGID: 'msgid'
-};
+export default function MessageList({ sourceDefinition, browser, selectedMessage, onBrowseFromChange, onMessageSelect }) {
+  const { sourceName } = sourceDefinition;
 
-export default function MessageList({ sourceDefinition, selectedMessage, onMessageSelect }) {
-  const { sourceName, type } = sourceDefinition;
-
-  const [sourceLabel, browseModes] =
-    (type === SOURCE_TYPE.QUEUE) ? [
-      'Queue', [
-        { value: BROWSE_MODE.HEAD, name: 'Queue Head' },
-        { value: BROWSE_MODE.TAIL, name: 'Queue End' },
-        { value: BROWSE_MODE.TIME, name: 'Date / Time' },
-        { value: BROWSE_MODE.MSGID, name: 'Message ID' }
-      ]] :
-      (type === SOURCE_TYPE.TOPIC) ? [
-        'Topic', [
-          { value: BROWSE_MODE.TIME, name: 'Date / Time' },
-          { value: BROWSE_MODE.MSGID, name: 'Message ID' }
-        ]
-      ] : [
-        '', [
-          { value: null }
-        ]
-      ];
-
-  const [browseMode, setBrowseMode] = useState(browseModes[0].value);
-  const [calendarVisible, setCalendarVisible] = useState(false);
-  const [calendarMinMax, setCalendarMinMax] = useState({});
-  const [dateTime, setDateTime] = useState(null);
-  const [msgIdText, setMsgIdText] = useState('');
-  const [startFrom, setStartFrom] = useState(null);
-
-  const browser = useQueueBrowser(sourceDefinition, startFrom);
-
+  const [isLoading, setIsLoading] = useState(false);
+  const [messages, setMessages] = useState([]);
   const [globalFilterValue, setGlobalFilterValue] = useState('');
   const [filters, setFilters] = useState({
     global: { value: null, matchMode: FilterMatchMode.CONTAINS }
   });
 
-  const [isLoading, setIsLoading] = useState(false);
-  const [messages, setMessages] = useState([]);
-
   const loadMessages = async (loader) => {
     setIsLoading(true);
-    setMessages(await loader());
+    try {
+      setMessages(await loader());
+    } catch (err) {
+      console.error('Error loding messages', err);
+      setMessages([]); // TODO: also show error toast notification?
+    }
     setIsLoading(false);
   };
 
@@ -72,65 +38,16 @@ export default function MessageList({ sourceDefinition, selectedMessage, onMessa
     loadMessages(() => browser.getFirstPage());
   }, [browser]);
 
-  useEffect(() => {
-    handleBrowseModeChange({ value: browseModes[0].value });
-  }, [type]);
-
-  const handleBrowseModeChange = (evt) => {
-    setBrowseMode(evt.value);
-    setDateTime(null);
-    setMsgIdText('');
-    switch (evt.value) {
-      case BROWSE_MODE.HEAD:
-        setStartFrom({ queuePosition: MESSAGE_ORDER.OLDEST });
-        break;
-      case BROWSE_MODE.TAIL:
-        setStartFrom({ queuePosition: MESSAGE_ORDER.NEWEST });
-        break;
-      case BROWSE_MODE.TIME:
-        setStartFrom({ fromTime: null });
-        break;
-      case BROWSE_MODE.MSGID:
-        setStartFrom({ fromTime: null });
-        break;
+  const handleRowSelection = (e) => {
+    if (e.value !== null) {
+      onMessageSelect?.(e.value);
     }
   };
-  const handleCalendarVisibleChangle = async () => {
-    if (calendarVisible) {
-      setCalendarVisible(false);
-    } else {
-      const { min, max } = await browser?.getMinMaxFromTime();
-      setCalendarMinMax({
-        min: new Date(min * 1000),
-        max: new Date(max * 1000)
-      });
-      setCalendarVisible(true);
-    }
-  };
-  const handleRefreshClick = () => {
-    if (browseMode === BROWSE_MODE.TIME) {
-      try {
-        const fromTime = dateTime ? Math.floor(Date.parse(dateTime) / 1000) : null;
-        setStartFrom({ fromTime });
-      } catch {
-        console.error('Invalid date format'); //TODO: send toast notification
-        setStartFrom({ fromTime: null });
-      }
-    }
 
-    if (browseMode === BROWSE_MODE.MSGID) {
-      try {
-        console.log(msgIdText);
-        const fromMsgId = msgIdText.startsWith('rmid1:') ?
-          window.parseInt(msgIdText.substring(24).replace('-', ''), 16) :
-          window.parseInt(msgIdText);
-        setStartFrom((fromMsgId > 0) ? { fromMsgId } : { fromTime: null });
-      } catch {
-        console.error('Invalid message id'); //TODO: send toast notification
-
-        setStartFrom({ fromTime: null });
-      }
-    }
+  const handleFilterChange = (e) => {
+    const value = e.target.value;
+    setFilters({ global: { ...filters.global, value } });
+    setGlobalFilterValue(value);
   };
 
   const handleFirstClick = () => {
@@ -143,26 +60,6 @@ export default function MessageList({ sourceDefinition, selectedMessage, onMessa
 
   const handlePrevClick = () => {
     loadMessages(() => browser.getPrevPage());
-  };
-
-  const handleCalendarChange = (e) => {
-    setDateTime(e.value);
-  };
-
-  const handleMsgIdTextChange = (e) => {
-    setMsgIdText(e.target.value);
-  }
-
-  const handleRowSelection = (e) => {
-    if (e.value !== null) {
-      onMessageSelect?.(e.value);
-    }
-  };
-
-  const handleFilterChange = (e) => {
-    const value = e.target.value;
-    setFilters({ global: { ...filters.global, value } });
-    setGlobalFilterValue(value);
   };
 
   const messageStatus = (message) => {
@@ -210,22 +107,7 @@ export default function MessageList({ sourceDefinition, selectedMessage, onMessa
   return (
     (sourceName) ? (
       <div style={{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%' }}>
-        <Toolbar className={classes.messageListToolbar}
-          start={() => <h3>{sourceLabel} | {sourceName}</h3>}
-          end={() =>
-            <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
-              <label>From:</label>
-              <Dropdown value={browseMode} onChange={handleBrowseModeChange} options={browseModes} optionLabel="name" />
-              {
-                (browseMode === BROWSE_MODE.HEAD || browseMode === BROWSE_MODE.TAIL) ?
-                  <InputText disabled={true} /> :
-                  (browseMode === BROWSE_MODE.MSGID) ?
-                    <InputText placeholder="ID or RGMID" value={msgIdText} onChange={handleMsgIdTextChange} /> :
-                    <Calendar showTime placeholder="Beginning of log" visible={calendarVisible} onVisibleChange={handleCalendarVisibleChangle} value={dateTime} onChange={handleCalendarChange} minDate={calendarMinMax.min} maxDate={calendarMinMax.max} />
-              }
-              <Button onClick={handleRefreshClick} size="small" disabled={!(browseMode === BROWSE_MODE.TIME || browseMode === BROWSE_MODE.MSGID)}>Refresh</Button>
-            </div>}
-        />
+        <MessageListToolbar sourceDefinition={sourceDefinition} onChange={onBrowseFromChange} />
         <div style={{ flex: '1', overflow: 'hidden' }}>
           <DataTable
             className={classes.messageListTable}

--- a/src/components/MessageList/index.jsx
+++ b/src/components/MessageList/index.jsx
@@ -14,7 +14,7 @@ import classes from './styles.module.css';
 
 export default function MessageList({ sourceDefinition, browser, selectedMessage, onBrowseFromChange, onMessageSelect }) {
   const { sourceName } = sourceDefinition;
-
+  const [replayLogTimeRange, setReplayLogTimeRange] = useState({ });
   const [isLoading, setIsLoading] = useState(false);
   const [messages, setMessages] = useState([]);
   const [globalFilterValue, setGlobalFilterValue] = useState('');
@@ -34,6 +34,7 @@ export default function MessageList({ sourceDefinition, browser, selectedMessage
   };
 
   useEffect(() => {
+    browser.getReplayTimeRange().then(range => setReplayLogTimeRange(range));
     setMessages([]);
     loadMessages(() => browser.getFirstPage());
   }, [browser]);
@@ -107,7 +108,7 @@ export default function MessageList({ sourceDefinition, browser, selectedMessage
   return (
     (sourceName) ? (
       <div style={{ display: 'flex', flexDirection: 'column', height: '100%', width: '100%' }}>
-        <MessageListToolbar sourceDefinition={sourceDefinition} onChange={onBrowseFromChange} />
+        <MessageListToolbar sourceDefinition={sourceDefinition} minTime={replayLogTimeRange.min} maxTime={replayLogTimeRange.max} onChange={onBrowseFromChange} />
         <div style={{ flex: '1', overflow: 'hidden' }}>
           <DataTable
             className={classes.messageListTable}

--- a/src/hooks/solace.jsx
+++ b/src/hooks/solace.jsx
@@ -1,48 +1,137 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import solace from '../utils/solace/solclientasync';
 
 import { useSempApi } from "../providers/SempClientProvider";
 
+const PAGE_SIZE = 100;
 const MIN_MSG_ID = 1n;
 const MAX_MSG_ID = 9223372036854775808n;
 
 export const SOURCE_TYPE = {
+  BASIC: 'basic',
   QUEUE: 'queue',
   TOPIC: 'topic'
 };
+
+export const BROWSE_MODE = {
+  BASIC: 'basic',
+  HEAD: 'head',
+  TAIL: 'tail',
+  TIME: 'time',
+  MSGID: 'msgid'
+};
+
+export const SUPPORTED_BROWSE_MODES = {
+  [SOURCE_TYPE.BASIC]: [
+    BROWSE_MODE.BASIC
+  ],
+  [SOURCE_TYPE.QUEUE]: [
+    BROWSE_MODE.BASIC,
+    BROWSE_MODE.HEAD,
+    BROWSE_MODE.TAIL,
+    BROWSE_MODE.TIME,
+    BROWSE_MODE.MSGID
+  ],
+  [SOURCE_TYPE.TOPIC]: [
+    BROWSE_MODE.TIME,
+    BROWSE_MODE.MSGID
+  ]
+}
 
 export const MESSAGE_ORDER = {
   OLDEST: 'oldest',   // Forward Browsing
   NEWEST: 'newest'    // Reverse Browsing
 };
 
-
+const BROWSER_STATE = {
+  CLOSED: 'closed',
+  OPENING: 'opening',
+  OPEN: 'open',
+  CLOSING: 'closing'
+};
+ 
 class BaseBrowser {
-  constructor({ sourceDefinition = { config: {} }, startFrom, sempApi, solclientFactory } = {}) {
+  constructor({ sourceDefinition, startFrom, sempApi, solclientFactory } = {}) {
+    this.instanceId = `${this.constructor.name} ${Math.random().toString().substring(2,6)}`;
+    // Specific browser instance behavior
     this.sourceDefinition = sourceDefinition;
     this.startFrom = startFrom;
 
-    const { config, topics } = sourceDefinition;
-    this.sempClient = sempApi?.getClient(config);
+    // Core API
+    this.sempApi = sempApi;
     this.solclientFactory = solclientFactory;
-    this.topics = topics;
-    this.replayLogName = undefined;
 
+    // Defined in open()
+    this.vpn = undefined;
+    this.sempClient = undefined;
+    this.session = undefined;
+    this.replayLogName = undefined;
+    this.topics = undefined;
+
+    // Page management
+    this.nextPage = null;
+    this.prevPages = [];
+    this.pageSize = PAGE_SIZE;
+
+    this.state = BROWSER_STATE.CLOSED;
+  }
+
+  async open() {
+    this.assertState(BROWSER_STATE.CLOSED);
+    this.state = BROWSER_STATE.OPENING;
+
+    const { sourceName, config, topics } = this.sourceDefinition || {};
     const {
       hostName, clientPort, useTls, vpn,
       clientUsername, clientPassword
-    } = config;
+    } = config || {};
 
-    this.session = hostName ? solclientFactory.createAsyncSession({
-      url: `${(useTls ? 'wss' : 'ws')}://${hostName}:${clientPort}`,
-      vpnName: vpn,
-      userName: clientUsername,
-      password: clientPassword
-    }) : null;
+    this.vpn = vpn;
 
-    this.nextPage = null;
-    this.prevPages = [];
-    this.pageSize = 50;
+    if (this.sempApi) {
+      this.sempClient = this.sempApi?.getClient(config);
+    }
+
+    if (this.solclientFactory) {
+      this.session = this.solclientFactory.createAsyncSession({
+        url: `${(useTls ? 'wss' : 'ws')}://${hostName}:${clientPort}`,
+        vpnName: this.vpn,
+        userName: clientUsername,
+        password: clientPassword
+      });
+    }
+
+    const { data: [{ replayLogName } = {}] } = await this.sempClient.getMsgVpnReplayLogs(this.vpn, { select: ['replayLogName'] });
+    this.replayLogName = replayLogName;
+
+    this.assertState(BROWSER_STATE.OPENING);
+
+    if (topics) {
+      this.topics = topics;
+    } else {
+      const { data: { networkTopic } } = await this.sempClient.getMsgVpnQueue(this.vpn, sourceName, { select: ['networkTopic'] });
+      const { data: subscriptions } = await this.sempClient.getMsgVpnQueueSubscriptions(this.vpn, sourceName);
+
+      this.topics = [
+        networkTopic,
+        ...subscriptions.map(s => s.subscriptionTopic)
+      ];
+    }
+
+    this.assertState(BROWSER_STATE.OPENING);
+    this.state = BROWSER_STATE.OPEN;
+  }
+
+  async close() { 
+    this.state = BROWSER_STATE.CLOSED;
+    this.assertState(BROWSER_STATE.CLOSED);
+  }
+
+
+  assertState(state) {
+    if(this.state !== state) {
+      throw new Error(`[${this.instanceId}] Invalid state: expected '${state}', current value '${this.state}'`);
+    }
   }
 
   getFirstPage() {
@@ -71,13 +160,11 @@ class BaseBrowser {
     return [];
   }
 
-  async getMessageMetaData({ queueName, fromMsgId = null, direction }) {
-    const { config: { vpn } } = this.sourceDefinition;
-    const count = this.pageSize;
+  async getMessageMetaData({ queueName, fromMsgId = null, direction, count = this.pageSize }) {
     const cursor = (fromMsgId !== null) ? [
       `<rpc><show><queue>`,
       `<name>${queueName}</name>`,
-      `<vpn-name>${vpn}</vpn-name>`,
+      `<vpn-name>${this.vpn}</vpn-name>`,
       `<messages/><${direction}/>`,
       `<msg-id>${fromMsgId}</msg-id>`,
       `<detail/><count/>`,
@@ -86,15 +173,12 @@ class BaseBrowser {
     ].join('') : undefined;
 
     const { data: msgMetaData } = await this.sempClient
-      .getMsgVpnQueueMsgs(vpn, queueName, { cursor, count });
+      .getMsgVpnQueueMsgs(this.vpn, queueName, { cursor, count });
 
     return msgMetaData;
   }
 
-  async replayToTempQueue({ sourceName, replayFrom }) {
-    const count = this.pageSize;
-
-    const topics = await this.getTopics(sourceName);
+  async replayToTempQueue({ sourceName, replayFrom, count = this.pageSize}) {
     await this.session.connect();
 
     const tempQueueName = `#QB/${sourceName}/${Date.now()}`;
@@ -113,7 +197,7 @@ class BaseBrowser {
               null
     });
 
-    await Promise.all(topics.map(topic => (
+    await Promise.all(this.topics.map(topic => (
       messageConsumer.addSubscription(
         this.solclientFactory.createTopicDestination(topic),
         topic,
@@ -121,6 +205,7 @@ class BaseBrowser {
       )))
     );
 
+    // Trigger Replay
     messageConsumer.connect();
     messageConsumer.disconnect();
 
@@ -141,37 +226,12 @@ class BaseBrowser {
     };
   }
 
-  async getReplayLogName() {
-    const { config: { vpn } } = this.sourceDefinition;
-    if (this.replayLogName === undefined) {
-      const { data: [{ replayLogName }] } = await this.sempClient.getMsgVpnReplayLogs(vpn, { select: ['replayLogName'] });
-      this.replayLogName = replayLogName;
-    }
-    return this.replayLogName;
-  }
-
-  async getTopics(sourceName) {
-    if (this.topics === undefined) {
-      const { config: { vpn } } = this.sourceDefinition;
-      const { data: { networkTopic } } = await this.sempClient.getMsgVpnQueue(vpn, sourceName, { select: ['networkTopic'] });
-      const { data: subscriptions } = await this.sempClient.getMsgVpnQueueSubscriptions(vpn, sourceName);
-
-      this.topics = [
-        networkTopic,
-        ...subscriptions.map(s => s.subscriptionTopic)
-      ];
-    }
-    return this.topics;
-  }
-
   async getQueueReplayFrom({ messageId }) {
     try {
-      const { config: { vpn } } = this.sourceDefinition;
-      const replayLogName = await this.getReplayLogName();
       const cursor = [
         `<rpc><show><replay-log>`,
-        `<name>${replayLogName}</name>`,
-        `<vpn-name>${vpn}</vpn-name>`,
+        `<name>${this.replayLogName}</name>`,
+        `<vpn-name>${this.vpn}</vpn-name>`,
         `<messages/><newest/>`,
         `<msg-id>${messageId}</msg-id>`,
         `<detail/>`,
@@ -180,7 +240,7 @@ class BaseBrowser {
       ].join('');
 
       const { data: msgMetaData } = await this.sempClient
-        .getMsgVpnReplayLogMsgs(vpn, replayLogName, { cursor, count: 2 });
+        .getMsgVpnReplayLogMsgs(this.vpn, this.replayLogName, { cursor, count: 2 });
       const [, nextOldestMessage] = msgMetaData;
       return ({
         afterMsg: nextOldestMessage.replicationGroupMsgId
@@ -220,8 +280,6 @@ class BaseBrowser {
     });
     return [...messageIdx.values()];
   }
-
-  close() { }
 }
 
 class LoggedMessagesReplayBrowser extends BaseBrowser {
@@ -231,8 +289,8 @@ class LoggedMessagesReplayBrowser extends BaseBrowser {
   }
 
   async getPage(page) {
-    const { fromMsgId } = page;
-    const { config: { vpn }, sourceName } = this.sourceDefinition;
+    const { fromMsgId } = page || {};
+    const { sourceName } = this.sourceDefinition;
     const count = this.pageSize;
 
     const replayFrom = fromMsgId ? await this.getQueueReplayFrom({ messageId: fromMsgId }) : page;
@@ -245,7 +303,7 @@ class LoggedMessagesReplayBrowser extends BaseBrowser {
         count
       });
 
-    const { data: tempQueue } = await this.sempClient.getMsgVpnQueue(vpn, tempQueueName);
+    const { data: tempQueue } = await this.sempClient.getMsgVpnQueue(this.vpn, tempQueueName);
     cleanupReplay();
 
     if (msgMetaData.length === 0) {
@@ -263,14 +321,12 @@ class LoggedMessagesReplayBrowser extends BaseBrowser {
 
   async getMinMaxFromTime() {
     try {
-      const { config: { vpn } } = this.sourceDefinition;
-      const replayLogName = await this.getReplayLogName();
       const minMaxSpooledTime = await Promise.all([
-        this.sempClient.getMsgVpnReplayLogMsgs(vpn, replayLogName, {
+        this.sempClient.getMsgVpnReplayLogMsgs(this.vpn, this.replayLogName, {
           cursor: [
             `<rpc><show><replay-log>`,
-            `<name>${replayLogName}</name>`,
-            `<vpn-name>${vpn}</vpn-name>`,
+            `<name>${this.replayLogName}</name>`,
+            `<vpn-name>${this.vpn}</vpn-name>`,
             `<messages/><oldest/>`,
             `<msg-id>${MIN_MSG_ID}</msg-id>`,
             `<detail/>`,
@@ -280,11 +336,11 @@ class LoggedMessagesReplayBrowser extends BaseBrowser {
           select: ['spooledTime'],
           count: 1
         }).then(({ data: [{ spooledTime }] }) => ['min', spooledTime]).catch(() => ['min', null]),
-        this.sempClient.getMsgVpnReplayLogMsgs(vpn, replayLogName, {
+        this.sempClient.getMsgVpnReplayLogMsgs(this.vpn, this.replayLogName, {
           cursor: [
             `<rpc><show><replay-log>`,
-            `<name>${replayLogName}</name>`,
-            `<vpn-name>${vpn}</vpn-name>`,
+            `<name>${this.replayLogName}</name>`,
+            `<vpn-name>${this.vpn}</vpn-name>`,
             `<messages/><newest/>`,
             `<msg-id>${MAX_MSG_ID}</msg-id>`,
             `<detail/>`,
@@ -304,7 +360,7 @@ class LoggedMessagesReplayBrowser extends BaseBrowser {
 
 class QueuedMessagesReplayBrowser extends BaseBrowser {
   constructor({ sourceDefinition, startFrom, sempApi, solclientFactory }) {
-    const messageOrderBy = startFrom.queuePosition;
+    const messageOrderBy = startFrom?.queuePosition;
     const isReversed = (messageOrderBy === MESSAGE_ORDER.NEWEST);
 
     super({
@@ -319,8 +375,8 @@ class QueuedMessagesReplayBrowser extends BaseBrowser {
   }
 
   async getPage(page) {
-    const { fromMsgId } = page;
-    const { config: { vpn }, sourceName } = this.sourceDefinition;
+    const { fromMsgId } = page || {};
+    const { sourceName } = this.sourceDefinition;
     const count = this.pageSize;
     const msgMetaData =
       await this.getMessageMetaData({
@@ -333,13 +389,13 @@ class QueuedMessagesReplayBrowser extends BaseBrowser {
       return [];
     }
 
-    const { data: queue } = await this.sempClient.getMsgVpnQueue(vpn, sourceName);
+    const { data: queue } = await this.sempClient.getMsgVpnQueue(this.vpn, sourceName);
 
     const lowestMsgId = msgMetaData[this.isReversed ? (msgMetaData.length - 1) : 0].msgId;
     const highestMsgId = msgMetaData[this.isReversed ? 0 : (msgMetaData.length - 1)].msgId;
 
     const replayFrom = await this.getQueueReplayFrom({ messageId: lowestMsgId });
-    const { messages, cleanupReplay } = await this.replayToTempQueue({ sourceName, replayFrom });
+    const { messages, cleanupReplay } = await this.replayToTempQueue({ sourceName, replayFrom, count: msgMetaData.length });
     cleanupReplay();
 
     this.nextPage = this.isReversed ?
@@ -351,28 +407,91 @@ class QueuedMessagesReplayBrowser extends BaseBrowser {
   }
 }
 
-const NULL_BROWSER = new BaseBrowser();
+class BasicQueueBrowser extends BaseBrowser {
+  async open() {
+    const { sourceName: queueName } = this.sourceDefinition;
 
-export function useQueueBrowser(sourceDefinition, startFrom) {
+    await super.open();
+    this.state = BROWSER_STATE.OPENING; // reset OPEN state to continue async operations
+    
+    await this.session.connect();
+    this.assertState(BROWSER_STATE.OPENING);
+
+    const queueDescriptor = { name: queueName, type: solace.QueueType.QUEUE };
+    this.queueBrowser = this.session.createQueueBrowser({ queueDescriptor });
+    await this.queueBrowser.connect();
+    this.assertState(BROWSER_STATE.OPENING);
+    this.nextPage = true;
+
+    this.state = BROWSER_STATE.OPEN;
+  }
+  async close() {
+    this.state = BROWSER_STATE.CLOSING;
+
+    this.queueBrowser?.disconnect();
+    this.session?.disconnect();
+
+    this.assertState(BROWSER_STATE.CLOSING);
+    this.state = closed;
+  }
+
+  async getPage() {
+    const { sourceName: queueName } = this.sourceDefinition;
+    const messages = await this.queueBrowser.readMessages(this.pageSize, 500);
+
+    if (messages.length === 0) {
+      return [];
+    }
+    const fromMsgId = messages[0].getGuaranteedMessageId()?.low;
+    const msgMetaData =
+      await this.getMessageMetaData({
+        queueName,
+        fromMsgId,
+        direction: MESSAGE_ORDER.OLDEST,
+        count: messages.length
+      });
+
+    return this.merge({ messages, msgMetaData });
+  }
+}
+
+class NullBrowser extends BaseBrowser{
+  async open() {}
+  async close() {}
+  async getPage() {return []};
+}
+
+const NULL_BROWSER = new NullBrowser();
+
+export function useQueueBrowsing() {
   const [browser, setBrowser] = useState(NULL_BROWSER);
   const sempApi = useSempApi();
 
-  useEffect(() => {
+  const updateBrowser = async (sourceDefinition, browseFrom) => {
     const solclientFactory = solace.SolclientFactory;
     const { type } = sourceDefinition;
+    const { browseMode, startFrom = {}} = browseFrom;
 
-    if (startFrom === null) {
-      return;
-    }
     const newBrowser = (type) ? (
-      (startFrom?.queuePosition) ?
-        new QueuedMessagesReplayBrowser({ sourceDefinition, startFrom, sempApi, solclientFactory }) :
-        new LoggedMessagesReplayBrowser({ sourceDefinition, startFrom, sempApi, solclientFactory })
+      (browseMode === BROWSE_MODE.BASIC || type === SOURCE_TYPE.BASIC) ?
+        new BasicQueueBrowser({ sourceDefinition, startFrom, sempApi, solclientFactory }) :
+        (browseMode === BROWSE_MODE.HEAD || browseMode === BROWSE_MODE.TAIL) ?
+          new QueuedMessagesReplayBrowser({ sourceDefinition, startFrom, sempApi, solclientFactory }) :
+          new LoggedMessagesReplayBrowser({ sourceDefinition, startFrom, sempApi, solclientFactory })
     ) : NULL_BROWSER;
+    try {
+      await browser?.close();
+    } catch (err) {
+      console.error('Error closing browser', err);
+    }
+    try {
+      await newBrowser?.open();
+      setBrowser(newBrowser);
+    } catch (err) {
+      console.error('Error opening browser', err);
+      setBrowser(NULL_BROWSER);
+    }
+  }
 
-    setBrowser(newBrowser);
-    return () => newBrowser.close();
-  }, [sourceDefinition, startFrom]);
-
-  return browser;
-};
+  return [browser, updateBrowser];
+}

--- a/src/hooks/solace.jsx
+++ b/src/hooks/solace.jsx
@@ -411,6 +411,12 @@ class QueuedMessagesReplayBrowser extends BaseBrowser {
 }
 
 class BasicQueueBrowser extends BaseBrowser {
+  constructor({ sourceDefinition, sempApi, solclientFactory }) {
+    super({ sourceDefinition, sempApi, solclientFactory });
+
+    this.didReadMessages = false;
+  }
+
   async open() {
     const { sourceName: queueName } = this.sourceDefinition;
 
@@ -435,7 +441,7 @@ class BasicQueueBrowser extends BaseBrowser {
     this.session?.disconnect();
 
     this.assertState(BROWSER_STATE.CLOSING);
-    this.state = closed;
+    this.state = BROWSER_STATE.CLOSED;
   }
 
   async getPage() {
@@ -453,8 +459,18 @@ class BasicQueueBrowser extends BaseBrowser {
         direction: MESSAGE_ORDER.OLDEST,
         count: messages.length
       });
-
+    
+    this.didReadMessages = true;
     return this.merge({ messages, msgMetaData });
+  }
+
+  async getFirstPage() {
+    if(this.didReadMessages) {
+      await this.close();
+      await this.open();
+      this.didReadMessages = false;
+    }
+    return await this.getPage();
   }
 }
 

--- a/src/utils/solace/semp/tauriClient.js
+++ b/src/utils/solace/semp/tauriClient.js
@@ -65,7 +65,7 @@ export class ApiClient {
       response: {}
     };
 
-    console.trace(`${httpMethod} ${url}`, args);
+    console.debug(`${httpMethod} ${url}`, args);
     const { username, password } = this.authentications.basicAuth;
 
     const resp = await fetch(urlParams.size ? `${url}?${urlParams}` : url, {


### PR DESCRIPTION
This PR adds basic queue browsing functionality for brokers that do not have replay enabled or when a user selects o use "Basic Mode" when browsing a queue from its head.

Due to the stateful nature of persisted browser instances, this required significant rework of the browser initialization code.

One usability change is that when picking a different "Browse From" option on the dropdown, the change is not instantaneous and requires the user to press Refresh. For modes that require selection of a start position such as timestamp or message ID, this means selecting the browsing mode and supplying an appropriate value can be done atomically.